### PR TITLE
Research Notebook page

### DIFF
--- a/src/components/article-link.js
+++ b/src/components/article-link.js
@@ -1,0 +1,11 @@
+import React from "react"
+import { Link } from "gatsby"
+
+const ArticleLink = ({ post }) => (
+  <li>
+    <Link to={`../` + post.frontmatter.slug}>{post.frontmatter.title}</Link>
+    &nbsp;<small>(Updated {post.frontmatter.date})</small>
+  </li>
+)
+
+export default ArticleLink

--- a/src/markdown-pages/Realtime-Collaborative-Systems.md
+++ b/src/markdown-pages/Realtime-Collaborative-Systems.md
@@ -1,20 +1,15 @@
 ---
-slug: "/articles/realtime-collaborative-systems"
-date: "2020-06-01"
-title: "Realtime Collaborative Systems"
+slug: "articles/realtime-collaborative-systems"
+date: 2020-07-02
+title: Realtime Collaborative Systems
 ---
-
 # Realtime Collaborative Systems
-
-_Thoughts on collaborative systems as they exist and where they might be going._
-
 ## Why Realtime Collaboration?
+I believe systems that allow humans to collaborate on work products in realtime are of critical importance in tackling the complexity inherent in the world of work. 
 
-I believe systems that allow humans to collaborate on work products in realtime are of critical importance in tackling the complexity inherent in the world of work.
 Furthermore, I believe realtime collaborative work to be one of the greatest joys in life, and the creation of systems that support fruitful realtime collaborative experiences to be a valuable end unto itself.
 
-## What Realtime Collaboration mean?
-
+## What is a Realtime Collaboration System?
 **Realtime** - systems that are "realtime" allow the user to interact a synchronous fashion, where both parties are interacting, perhaps not equally, with the work and moving it to completion. This is contrasted with "asynchronous" systems that do support collaboration, but the individuals working are working at different times, more like a turn-based board game.
 
 **Collaborative** - systems that allow humans to interact with one another in a collaborative fashion, bringing together their individual skills and knowledge to work together.
@@ -22,24 +17,25 @@ Furthermore, I believe realtime collaborative work to be one of the greatest joy
 **System** - a system refers to any means, technological, digital, analog or otherwise, that facilitates realtime, collaborative work between humans.
 
 ## What about Asynchronous Collaboration?
-
 Asynchronous collaboration systems are incredibly important! There are use cases for realtime collaboration and there are use cases for asynchronous collaboration. It seems to me that much of our product development over the past decades has gone into asynchronous collaboration systems and they've gotten pretty good.
+
 From project management tools (systems like Kanban) to Git (distributed version control systems), humans have built some incredible systems for asynchronous collaboration and they've driven massive technological improvements.
+
 Tremendous potential for improvement still exists in the area of asynchronous collaboration, but I think the largest gaps exist in our ability to effectively collaborate in realtime.
 
 ## What about Knowledge Representation?
-
 A critical component of _any_ collaboration system is the way knowledge is represented in that system. We have some domains with very advanced knowledge representations; source code and 3D models come to mind. We have other domains where knowledge representation that is still quite rudimentary.[1]
+
 In order to effectively build systems for collaboration, the issue of how to represent knowledge effectively in such a way that it can be interacted with reliably will have to be tackled as well.
+
 I would argue that knowledge representation is largely domain-specific and therefore will best be tackled "bottom up" by starting with a motivating problem.
 
 ## Examples
-
 Interestingly, perhaps the most powerful realtime collaboration systems of all time is that of human language. The invention of language allowed for humans to collaborate, share representations of knowledge,
-Conversely, the most powerful asynchronous collaboration systems is perhaps written language.
+
+Conversely, the most powerful asynchronous collaboration systems is perhaps written language. 
 
 ### Gold standard: The Whiteboard
-
 - Pair programming
 - Figma
 - Google Docs
@@ -51,9 +47,10 @@ Conversely, the most powerful asynchronous collaboration systems is perhaps writ
 - Chat
 
 ## Digital versus Analog
-
 By and large, current collaboration systems tend to be either purely analog or purely digital. Our digital tools often act as only a physical "window" into a digital space. This does a massive disservice to our _bodies_ and the realization that our _embodied_ nature.
+
 There is tremendous opportunity in bridging the digital and analog worlds, combining the best of our bodies and minds into unified systems.
+
 More to say here.
 
 **References:**
@@ -63,11 +60,10 @@ More to say here.
 - See [Andrei State's Technical Artwork](https://www.cs.unc.edu/~andrei/artagrafica/technical.htm)
 
 ## Distributed vs In-person Collaboration
-
 The needs of our modern world make building systems for real-time collaboration more important than ever.
 
 ## An Idea
-
 Maybe a 3D virtual space crafted for realtime collaboration makes sense after all.
 
 [1] One knowledge representation regularly bugs me is the "cooking recipe" - the state of the art is still a 3x5 index card with ingredients and steps. So much room for improvement!
+

--- a/src/markdown-pages/high-performance-organizations-and-growth-by-douglas-engelbart.md
+++ b/src/markdown-pages/high-performance-organizations-and-growth-by-douglas-engelbart.md
@@ -1,0 +1,23 @@
+---
+slug: "articles/high-performance-organizations-and-growth-by-douglas-engelbart"
+date: 2020-07-02
+title: High-Performance Organizations and Growth by Douglas Engelbart
+---
+# High-Performance Organizations and Growth by Douglas Engelbart
+Talk: [YouTube](https://www.youtube.com/watch?v=sQzznHqFrYg)
+
+There were lots of interesting ideas in this talk. I'll cover a few of them below.
+
+## C Activities
+[image:B07A7F90-54F8-4BF1-AF6E-A7EB02C2E7EF-827-000038EBC4C4B00A/132803_01.jpg]
+From http://dougengelbart.org/images/pubs/papers/augment-132803/132803_01.jpg
+
+- **A Activities** are the core activities of the business. For Lambda School, that would be teaching classes, sourcing jobs for students, admissions, etc.
+- **B Activities** are activities that improve the ability of the company to perform A Activities. For Lambda School, that would be the Product/Engineering squads that work with each organization - they build new systems that 
+- **C Activities** are activities that improve our capabilities for improvement. The Lambda School example would be the platform team themselves, building "paved roads" that allows our B Activity Teams to more productively improve their work.
+
+When I engage in "meta-work", it's often "C Activity" work. Also, building a framework like [RedwoodJS](https://redwoodjs.com) or [Croquet](https://croquet.io) is very much "C Activity".
+
+References:
+- Broad Overview: https://www.dougengelbart.org/content/view/248/260/
+- Summary: https://www.dougengelbart.org/content/view/115/000/

--- a/src/markdown-pages/on-thinking-software-and-ideas.md
+++ b/src/markdown-pages/on-thinking-software-and-ideas.md
@@ -3,7 +3,9 @@ slug: "articles/on-thinking-software-and-ideas"
 date: 2020-07-02
 title: On Thinking, Software, and Ideas
 ---
+
 # On Thinking, Software, and Ideas
+
 [image:1617C561-A611-4B6E-9E2E-8E5136D43BEF-429-0000010E2D063404/89DD28C6-E3DB-400A-8EC7-1A3957FA0872.png]
 
 I'm approaching 40, and in that process of reviewing milestones of my life, I've been reflecting on my career and my life and my contributions and wondering what comes of it.
@@ -12,7 +14,7 @@ One big idea that dominates the other thoughts is the thought of how we learn, h
 
 I've been at the software game, professionally, for about 18 years. As I move into the second half of my career, I'm thinking about what I should focus on. And increasingly I'm thinking about big ideas that span the fields of software development, human potential, futurism, and tool-building.
 
-Technology is merely a tool. 
+Technology is merely a tool.
 
 > In a word, the computer scientist is a toolsmith—no more, but no less. It is an honorable calling.
 
@@ -21,13 +23,14 @@ Technology is merely a tool.
 > That swordsmith is successful whose clients die of old age.
 
 ## Thinking Thoughts That Bend The Arc of the Universe
+
 What are the big thoughts in my mind?
 
 - Integrate the analog and the digital
 - We need more screens and information radiators in our physical spaces
 - Knowledge Management Systems
-	- Reading
-	- Writing
-	- Publishing
-	- Bookmarking
-	- Personal systems for managing knowledge
+    - Reading
+    - Writing
+    - Publishing
+    - Bookmarking
+    - Personal systems for managing knowledge

--- a/src/markdown-pages/on-thinking-software-and-ideas.md
+++ b/src/markdown-pages/on-thinking-software-and-ideas.md
@@ -1,0 +1,33 @@
+---
+slug: "articles/on-thinking-software-and-ideas"
+date: 2020-07-02
+title: On Thinking, Software, and Ideas
+---
+# On Thinking, Software, and Ideas
+[image:1617C561-A611-4B6E-9E2E-8E5136D43BEF-429-0000010E2D063404/89DD28C6-E3DB-400A-8EC7-1A3957FA0872.png]
+
+I'm approaching 40, and in that process of reviewing milestones of my life, I've been reflecting on my career and my life and my contributions and wondering what comes of it.
+
+One big idea that dominates the other thoughts is the thought of how we learn, how we craft thoughts and ideas into physical things that we bring into the world. I consider myself a maker first and a thinker second, but how I think influences what I make, and so I've been forced to think more deeply about the things that I make. What ideas influence me? Is my thinking clear? How am I shaping the world and why? What ideas can I in turn shape that will actually mold what makers make for many years from now?
+
+I've been at the software game, professionally, for about 18 years. As I move into the second half of my career, I'm thinking about what I should focus on. And increasingly I'm thinking about big ideas that span the fields of software development, human potential, futurism, and tool-building.
+
+Technology is merely a tool. 
+
+> In a word, the computer scientist is a toolsmith—no more, but no less. It is an honorable calling.
+
+[image:073C863D-E7A5-4C97-9EC8-B104EF3862A1-429-0000032E306EAC7E/2B41C771-DFDF-455E-9B9C-582EE30317D1.png]
+
+> That swordsmith is successful whose clients die of old age.
+
+## Thinking Thoughts That Bend The Arc of the Universe
+What are the big thoughts in my mind?
+
+- Integrate the analog and the digital
+- We need more screens and information radiators in our physical spaces
+- Knowledge Management Systems
+	- Reading
+	- Writing
+	- Publishing
+	- Bookmarking
+	- Personal systems for managing knowledge

--- a/src/pages/articles.js
+++ b/src/pages/articles.js
@@ -17,6 +17,14 @@ const ArticlesPage = ({
   return (
     <Layout>
       <SEO title="Jess Martin - Articles" />
+      <div className="article-warning">
+        <p>
+          <strong>⚠️ Warning!</strong> These are in-progress research notes
+          exported directly from Jess's research notebook. The ideas contained
+          in these notes are still under active development.
+        </p>
+      </div>
+
       <h2>Research Notebook</h2>
 
       <p>

--- a/src/pages/articles.js
+++ b/src/pages/articles.js
@@ -1,0 +1,52 @@
+import React from "react"
+import { graphql } from "gatsby"
+
+import ArticleLink from "../components/article-link"
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+
+const ArticlesPage = ({
+  data: {
+    allMarkdownRemark: { edges },
+  },
+}) => {
+  const Articles = edges.map(edge => (
+    <ArticleLink key={edge.node.id} post={edge.node} />
+  ))
+
+  return (
+    <Layout>
+      <SEO title="Jess Martin - Articles" />
+      <h2>Research Notebook</h2>
+
+      <p>
+        This is a collection of notes from Jess's research notebook. Note that
+        these notes are raw and largely unedited. They represent ideas that are
+        in progress.
+      </p>
+
+      <h3>Notes</h3>
+      <ul>{Articles}</ul>
+    </Layout>
+  )
+}
+
+export default ArticlesPage
+
+export const pageQuery = graphql`
+  query {
+    allMarkdownRemark(sort: { order: DESC, fields: [frontmatter___date] }) {
+      edges {
+        node {
+          id
+          excerpt(pruneLength: 250)
+          frontmatter {
+            date(formatString: "MMMM DD, YYYY")
+            slug
+            title
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -87,7 +87,15 @@ const IndexPage = () => (
     </ul>
 
     <h3>Writings</h3>
-    <p>A collection of writings across various subjects.</p>
+    <p>
+      <strong>
+        <Link to="/articles">Research Notebook</Link>
+      </strong>{" "}
+      - a collection of research notes exported directly from Jess's research
+      notebooks.
+    </p>
+
+    <p>A collection of articles across various subjects.</p>
     <ul>
       <li>
         <a href="https://medium.com/@jessmartin/how-to-trello-your-project-81429919e6a3">

--- a/src/templates/blogTemplate.js
+++ b/src/templates/blogTemplate.js
@@ -1,5 +1,6 @@
 import React from "react"
 import { graphql } from "gatsby"
+import { Link } from "gatsby"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
@@ -14,9 +15,10 @@ export default function Template({ data }) {
         <div className="article">
           <div className="article-warning">
             <p>
-              <strong>⚠️ Warning!</strong> This note is an in-progress note
-              exported raw from Jess's note-taking system. The ideas in this
-              note are still under active development.
+              <strong>⚠️ Warning!</strong> This is an in-progress research note
+              exported directly from{" "}
+              <Link to="/articles">Jess's note-taking system</Link>. The ideas
+              in this note are still under active development.
             </p>
           </div>
           <p class="small">


### PR DESCRIPTION
Adds a `/articles` page which lists a few notes exported directly from my notebooks.

![image](https://user-images.githubusercontent.com/27258/86407855-d21bdb00-bc83-11ea-947c-722ac4655769.png)

This is part of the Writing Workflow that I'm working on and will document more about soon!