### PR TITLE
Fix iframe embedding, maybe

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,10 +5,6 @@ module.exports = {
     author: `@jessmartin`,
   },
   plugins: [
-    {
-      resolve: `gatsby-plugin-netlify`,
-      options: { mergeSecurityHeaders: false, }
-    },
     `gatsby-plugin-react-helmet`,
     {
       resolve: `gatsby-source-filesystem`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7363,20 +7363,6 @@
         "sharp": "^0.30.3"
       }
     },
-    "gatsby-plugin-netlify": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-netlify/-/gatsby-plugin-netlify-4.4.0.tgz",
-      "integrity": "sha512-AfgcTsD4T+dvgoQlbTxIIdLRFV6wj96JTXcN6EoQBzC+XYQUFWYLTAVxM1NnQ3OhVm8FDKsMlT41BpnpQzBVFw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.16.7",
-        "fs-extra": "^10.0.0",
-        "gatsby-core-utils": "^3.5.2",
-        "kebab-hash": "^0.1.2",
-        "lodash": "^4.17.21",
-        "webpack-assets-manifest": "^5.0.6"
-      }
-    },
     "gatsby-plugin-offline": {
       "version": "5.19.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-offline/-/gatsby-plugin-offline-5.19.0.tgz",
@@ -9268,15 +9254,6 @@
         "object.assign": "^4.1.2"
       }
     },
-    "kebab-hash": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/kebab-hash/-/kebab-hash-0.1.2.tgz",
-      "integrity": "sha512-BTZpq3xgISmQmAVzkISy4eUutsUA7s4IEFlCwOBJjvSFOwyR7I+fza+tBc/rzYWK/NrmFHjfU1IhO3lu29Ib/w==",
-      "dev": true,
-      "requires": {
-        "lodash.kebabcase": "^4.1.1"
-      }
-    },
     "keyv": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.3.tgz",
@@ -9452,15 +9429,6 @@
       "resolved": "https://registry.npmjs.org/lock/-/lock-1.1.0.tgz",
       "integrity": "sha512-NZQIJJL5Rb9lMJ0Yl1JoVr9GSdo4HTPsUEWsSFzB8dE8DSoiLCVavWZPi7Rnlv/o73u6I24S/XYc/NmG4l8EKA=="
     },
-    "lockfile": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
-      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
-      "dev": true,
-      "requires": {
-        "signal-exit": "^3.0.2"
-      }
-    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -9510,18 +9478,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
-    "lodash.has": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=",
-      "dev": true
-    },
-    "lodash.kebabcase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
-      "dev": true
     },
     "lodash.map": {
       "version": "4.6.0",
@@ -13829,34 +13785,6 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
           "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w=="
-        }
-      }
-    },
-    "webpack-assets-manifest": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/webpack-assets-manifest/-/webpack-assets-manifest-5.1.0.tgz",
-      "integrity": "sha512-kPuTMEjBrqZQVJ5M6yXNBCEdFbQQn7p+loNXt8NOeDFaAbsNFWqqwR0YL1mfG5LbwhK5FLXWXpuK3GuIIZ46rg==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.0",
-        "deepmerge": "^4.0",
-        "lockfile": "^1.0",
-        "lodash.get": "^4.0",
-        "lodash.has": "^4.0",
-        "schema-utils": "^3.0",
-        "tapable": "^2.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.8",
-            "ajv": "^6.12.5",
-            "ajv-keywords": "^3.5.2"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "react-helmet": "^6.1.0"
   },
   "devDependencies": {
-    "gatsby-plugin-netlify": "^4.4.0",
     "prettier": "^2.7.1"
   },
   "keywords": [


### PR DESCRIPTION
According to [the gatsby netlify plugin docs](https://www.gatsbyjs.com/plugins/gatsby-plugin-netlify/),

> When not to use the plugin: In case you just want to use your own _redirects or _headers file for Netlify with Gatsby, you don’t need this plugin. Instead, move those files in /static/_redirects, /static/_headers and Gatsby will copy them to your root folder during build where Netlify will pick them up. Note that this plugin is still required if you want to use SSR or DSG rendering.

Let's see if we can get those default security headers out of there and use our `X-Frame-Options` from our own `_headers_ file. 